### PR TITLE
Ensure percentage does not exceed 100

### DIFF
--- a/src/assets/ReadingPositionIndicator.js
+++ b/src/assets/ReadingPositionIndicator.js
@@ -133,7 +133,7 @@ export default class ReadingPositionIndicator {
       this.state.virtualDOM.progressBarPositionStyleTransform = 'scaleX(0)';
     } else {
       const offset = scrollPosition - this.state.rpiArea.top;
-      const percentage = Math.round((100 * offset) / Math.max(maxHeight, 1));
+      const percentage = Math.min(Math.round((100 * offset) / Math.max(maxHeight, 1)),100);
 
       if (this.props.progressBar.show) {
         this.state.virtualDOM.progressBarPositionStyleTransform = `scaleX(${percentage /


### PR DESCRIPTION
I noticed that the RPI percentage was going beyond 100 in my project. This fix will set a maximum percent value of 100 if the `offset` is greater than the `maxHeight`